### PR TITLE
Added Support for MacOS

### DIFF
--- a/Apple Intelligence Chat/SettingsView.swift
+++ b/Apple Intelligence Chat/SettingsView.swift
@@ -42,7 +42,9 @@ struct SettingsView: View {
                 }
             }
             .navigationTitle("Settings")
-            .navigationBarTitleDisplayMode(.inline)
+#if os(iOS)
+.navigationBarTitleDisplayMode(.inline)
+#endif
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }


### PR DESCRIPTION
Summary

  • Added macOS platform support by implementing platform-specific UI adaptations

  Changes

  - Added #if os(iOS) conditionals around iOS-specific haptic feedback code
  - Updated navigation bar styling to use inline display mode only on iOS
  - Modified toolbar items to use text labels instead of SF Symbols on macOS
  - Wrapped iOS-specific UIImpactFeedbackGenerator and UISelectionFeedbackGenerator usage