### PR TITLE
Fix: use partialResponse.content instead of updateLastMessage(with: partialResponse)

### DIFF
--- a/Apple Intelligence Chat/ContentView.swift
+++ b/Apple Intelligence Chat/ContentView.swift
@@ -191,7 +191,7 @@ struct ContentView: View {
 #if os(iOS)
                         hapticStreamGenerator.selectionChanged()
 #endif
-                        updateLastMessage(with: partialResponse)
+                        updateLastMessage(with: partialResponse.content)
                     }
                 } else {
                     let response = try await currentSession.respond(to: prompt, options: options)


### PR DESCRIPTION
The updateLastMessage(with:) function expects a String, but 
LanguageModelSession.ResponseStream<String>.Snapshot is not a String. 
This commit fixes the type mismatch by passing Snapshot.content, 
which contains the partially generated response text, ensuring 
the app compiles and streams output correctly.